### PR TITLE
bump terraform-equinix-fabric-connection module version to 0.4.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "random_string" "this" {
 
 module "equinix-fabric-connection" {
   source = "equinix-labs/fabric-connection/equinix"
-  version = "0.3.1"
+  version = "0.4.0"
 
   # required variables
   notification_users = var.fabric_notification_users


### PR DESCRIPTION
Note: In fabric connection modules for cloud providers all the connection logic happens in submodule `terraform-equinix-fabric-connection`, therefore user-agent will include the `terraform-equinix-fabric-connection` metadata module name and not `terraform-equinix-fabric-connection-aws` in this case. 