### PR TITLE
fix: remove speed_unit from fabric connection module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,6 @@ module "equinix-fabric-connection" {
   vlan_stag                 = var.fabric_vlan_stag
   service_token_id          = var.fabric_service_token_id
   speed                     = var.fabric_speed
-  speed_unit                = "MB"
   purchase_order_number    = var.fabric_purchase_order_number
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "fabric_connection_speed" {
 
 output "fabric_connection_speed_unit" {
   description = "Connection speed unit."
-  value       = module.equinix-fabric-connection.primary_connection.speed_unit
+  value       = "MB"
 }
 
 output "fabric_connection_seller_metro" {


### PR DESCRIPTION
`speed_unit` was deprecated in last fabric module and this change is required to pass tests in https://github.com/equinix-labs/terraform-equinix-fabric-connection-aws/pull/18